### PR TITLE
dont replace docker image version to 5.0.3-2

### DIFF
--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "5.0.3-2"
+appVersion: "5.0.3-3"
 description: High performance, self-hosted, newsletter and mailing list manager with a modern dashboard.
 name: listmonk
 type: application
-version: 5.0.3-2
+version: 5.0.3-3

--- a/charts/listmonk/README.md
+++ b/charts/listmonk/README.md
@@ -2,7 +2,7 @@
 
 [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](#)
 [![Version: 5.0.3-2](https://img.shields.io/badge/Version-5.0.3-2-informational?style=flat-square)](#)
-[![AppVersion: 5.0.3-2](https://img.shields.io/badge/AppVersion-5.0.3-2-informational?style=flat-square)](#)
+[![AppVersion: 5.0.3](https://img.shields.io/badge/AppVersion-5.0.3-informational?style=flat-square)](#)
 
 High performance, self-hosted, newsletter and mailing list manager with a modern dashboard.
 
@@ -36,7 +36,7 @@ $ helm uninstall --namespace listmonk listmonk
 | listmonk.admin.password            | string | `""`                  | the admin password                                                                                             |
 | listmonk.admin.username            | string | `""`                  | the admin username                                                                                             |
 | listmonk.image.repository          | string | `"listmonk/listmonk"` | the listmonk image repository                                                                                  |
-| listmonk.image.tag                 | string | `"v5.0.3-2"`            | the listmonk image tag                                                                                         |
+| listmonk.image.tag                 | string | `"v5.0.3"`            | the listmonk image tag                                                                                         |
 | listmonk.replicas                  | int    | `1`                   | the number of listmonk deployment replicas                                                                     |
 | postgres.database                  | string | `"listmonk"`          | the postgres database name                                                                                     |
 | postgres.enabled                   | bool   | `true`                | enable internal postgres                                                                                       |

--- a/charts/listmonk/README.md
+++ b/charts/listmonk/README.md
@@ -1,7 +1,7 @@
 # listmonk
 
 [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](#)
-[![Version: 5.0.3-2](https://img.shields.io/badge/Version-5.0.3-2-informational?style=flat-square)](#)
+[![Version: 5.0.3-3](https://img.shields.io/badge/Version-5.0.3-3-informational?style=flat-square)](#)
 [![AppVersion: 5.0.3](https://img.shields.io/badge/AppVersion-5.0.3-informational?style=flat-square)](#)
 
 High performance, self-hosted, newsletter and mailing list manager with a modern dashboard.
@@ -15,7 +15,7 @@ $ helm upgrade listmonk listmonk \
   --namespace listmonk \
   --repo https://th0th.github.io/helm-charts \
   --values values.yaml \
-  --version 5.0.3-2
+  --version 5.0.3-3
 ```
 
 ## Uninstall

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -14,7 +14,7 @@ listmonk:
     # -- the listmonk image repository
     repository: listmonk/listmonk
     # -- the listmonk image tag
-    tag: v5.0.3-2
+    tag: v5.0.3
   # -- the number of listmonk deployment replicas
   replicas: 1
 postgres:


### PR DESCRIPTION
In the mass update, I managed to update the docker image also from 5.0.3 to 5.0.3-2. Should I bump the version of the chart again. 

