### PR TITLE
Allow wrapper chart usage

### DIFF
--- a/charts/listmonk/values.schema.json
+++ b/charts/listmonk/values.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "description": "Schema for listmonk helm chart values",
     "properties": {
         "ingress": {


### PR DESCRIPTION
As additional properties are not allowed, this chart is prevented from being used in a wrapper-chart-strategy.
Could this be allowed?